### PR TITLE
feat: add location selection for public job applications and auto-com…

### DIFF
--- a/src/features/external_posting/components/BasicDetailsForm.tsx
+++ b/src/features/external_posting/components/BasicDetailsForm.tsx
@@ -63,6 +63,7 @@ interface BasicDetailsFormProps {
     value: string | number | null,
   ) => void;
   errorFields: ValidationError | null;
+  computedHeadcount?: number | null;
 }
 
 // To do: Optimize the function on onChange, it is laggy
@@ -73,6 +74,7 @@ export const BasicDetailsForm = ({
   onInputChange,
   handleJobPostingChange,
   errorFields,
+  computedHeadcount,
 }: BasicDetailsFormProps) => {
   const parseNullableNumber = (value: string): number | null => {
     const trimmedValue = value.trim();
@@ -491,15 +493,10 @@ export const BasicDetailsForm = ({
               <FieldLabel>Headcounts Needed *</FieldLabel>
               <Input
                 type="number"
-                value={formData.job_posting.number_of_vacancies ?? ""}
-                onChange={(e) =>
-                  handleJobPostingChange(
-                    "number_of_vacancies",
-                    parseNullableNumber(e.target.value),
-                  )
-                }
-                placeholder="Enter number of positions"
+                value={computedHeadcount ?? ""}
+                placeholder="Auto-computed from locations"
                 min={0}
+                disabled
               />
               {getJobError("number_of_vacancies") && (
                 <FieldError>{getJobError("number_of_vacancies")}</FieldError>

--- a/src/features/external_posting/components/steps/Step01.tsx
+++ b/src/features/external_posting/components/steps/Step01.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { Card } from "@/shared/components/ui/card";
 import { BasicDetailsForm } from "../BasicDetailsForm";
@@ -8,7 +8,12 @@ import {
   type LocationEntryDb,
   type LocationEntryLocal,
 } from "@/features/location";
-import { BatchManagement, useBatchEntries } from "@/features/batch";
+import {
+  BatchManagement,
+  useBatchEntries,
+  type BatchEntryDb,
+  type BatchEntryLocal,
+} from "@/features/batch";
 import type {
   PositionBase,
   PositionFormData,
@@ -58,9 +63,27 @@ export default function Step01({
     setSelectedLocationId(id);
   }
 
-  // const filteredBatches = selectedLocationId
-  //   ? batches.filter((batch) => batch.locationId === selectedLocationId)
-  //   : [];
+  const computedTotalHeadcount = useMemo(() => {
+    return locations.reduce((total, loc) => {
+      if ((loc as LocationEntryDb)._delete) return total;
+
+      const locId =
+        (loc as LocationEntryDb).id ?? (loc as LocationEntryLocal).tempId;
+
+      if (loc.with_batch) {
+        const batchSum = batches
+          .filter(
+            (b) =>
+              b.location === locId &&
+              !(b as BatchEntryDb)._delete,
+          )
+          .reduce((sum, b) => sum + (b.headcount || 0), 0);
+        return total + batchSum;
+      }
+
+      return total + (loc.headcount ?? 0);
+    }, 0);
+  }, [locations, batches]);
 
   return (
     <Card className="p-6">
@@ -69,6 +92,7 @@ export default function Step01({
         onInputChange={handleInputChange}
         handleJobPostingChange={handleJobPostingChange}
         errorFields={error ?? null}
+        computedHeadcount={computedTotalHeadcount || null}
       />
 
       <LocationManagement

--- a/src/features/external_posting/hooks/useExternalPostingMutation.ts
+++ b/src/features/external_posting/hooks/useExternalPostingMutation.ts
@@ -25,6 +25,20 @@ export function useExternalPostingMutation() {
   const submitExternalPosting = useCallback(
     async (params: { formData: PositionFormData; updateMode?: boolean }) => {
       const { formData, updateMode } = params;
+
+      const totalHeadcount = (formData.locations ?? []).reduce((total, loc) => {
+        if ((loc as Record<string, unknown>)._delete) return total;
+        const locId = (loc as Record<string, unknown>).id ?? (loc as Record<string, unknown>).tempId;
+        if (loc.with_batch) {
+          const batchSum = (formData.batches ?? [])
+            .filter((b: Record<string, unknown>) => b.location === locId && !b._delete)
+            .reduce((sum: number, b: Record<string, unknown>) => sum + ((b.headcount as number) || 0), 0);
+          return total + batchSum;
+        }
+        return total + ((loc.headcount as number) ?? 0);
+      }, 0);
+      formData.job_posting.number_of_vacancies = totalHeadcount || null;
+
       const payload = stateToDataFormatClient(formData);
 
       if (updateMode) {

--- a/src/features/jobs/public/components/application/LocationSelectionSection.tsx
+++ b/src/features/jobs/public/components/application/LocationSelectionSection.tsx
@@ -1,0 +1,71 @@
+import type { LocationPublicSummary } from "../../types/jobApply.types";
+
+interface LocationSelectionSectionProps {
+  locations: LocationPublicSummary[];
+  selectedLocationId: number | null;
+  onLocationSelect: (locationId: number | null) => void;
+}
+
+export function LocationSelectionSection({
+  locations,
+  selectedLocationId,
+  onLocationSelect,
+}: LocationSelectionSectionProps) {
+  if (!locations || locations.length === 0) {
+    return null;
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    onLocationSelect(value ? Number(value) : null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900">
+          Preferred Deployment Site
+        </h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Select your preferred work location for this position.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="location-select"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Location <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="location-select"
+          value={selectedLocationId ?? ""}
+          onChange={handleChange}
+          className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+          required
+        >
+          <option value="" disabled>
+            -- Select a location --
+          </option>
+          {locations.map((loc) => {
+            const isFull = loc.available <= 0;
+            const label = isFull
+              ? `${loc.name} (Full — ${loc.booked}/${loc.headcount})`
+              : `${loc.name} (${loc.available} slot${loc.available !== 1 ? "s" : ""} remaining)`;
+            return (
+              <option key={loc.id} value={loc.id} disabled={isFull}>
+                {label}
+              </option>
+            );
+          })}
+        </select>
+        {selectedLocationId && (
+          <p className="text-xs text-gray-400">
+            Batch will be assigned by the system based on availability.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/jobs/public/components/steps/StepLocation.tsx
+++ b/src/features/jobs/public/components/steps/StepLocation.tsx
@@ -1,0 +1,22 @@
+import { LocationSelectionSection } from "../application/LocationSelectionSection";
+import type { LocationPublicSummary } from "../../types/jobApply.types";
+
+interface StepLocationProps {
+  locations: LocationPublicSummary[];
+  selectedLocationId: number | null;
+  onLocationSelect: (locationId: number | null) => void;
+}
+
+export default function StepLocation({
+  locations,
+  selectedLocationId,
+  onLocationSelect,
+}: StepLocationProps) {
+  return (
+    <LocationSelectionSection
+      locations={locations}
+      selectedLocationId={selectedLocationId}
+      onLocationSelect={onLocationSelect}
+    />
+  );
+}

--- a/src/features/jobs/public/hooks/useApplicationForm.ts
+++ b/src/features/jobs/public/hooks/useApplicationForm.ts
@@ -8,6 +8,7 @@ import type {
   QuestionnaireAnswers,
   WorkExperienceEntry,
 } from "../types/application_form.types";
+import type { LocationPublicSummary } from "../types/jobApply.types";
 
 const initialPersonalData: PersonalFormData = {
   firstName: null,
@@ -67,10 +68,12 @@ const data = {
 export const useApplicationForm = (
   jobTitle?: string,
   prefillData?: Partial<ApplicationFormData>,
+  locations?: LocationPublicSummary[],
 ) => {
   const [formData, setFormData] = useState<ApplicationFormData>(data);
   const [currentStage, setCurrentStage] = useState(1);
   const [acceptTerms, setAcceptTerms] = useState(false);
+  const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null);
 
   // Apply prefill data when it becomes available (e.g. after async load).
   // A ref guard ensures we only merge once so user edits are not overwritten
@@ -212,12 +215,20 @@ export const useApplicationForm = (
     }
   };
 
+  const handleLocationSelect = (locationId: number | null) => {
+    setSelectedLocationId(locationId);
+  };
+
   return {
     formData,
     currentStage,
     acceptTerms,
+    selectedLocationId,
+    locations,
 
     setAcceptTerms,
+    setSelectedLocationId,
+    handleLocationSelect,
 
     handleInputPersonalInfo,
     handleInputJobDetails,

--- a/src/features/jobs/public/types/jobApply.types.ts
+++ b/src/features/jobs/public/types/jobApply.types.ts
@@ -40,15 +40,27 @@ export interface PublicApplyApplicationForm {
   questionnaire: PublicApplyQuestionnaire;
 }
 
+export interface LocationPublicSummary {
+  id: number;
+  name: string;
+  headcount: number;
+  booked: number;
+  hired: number;
+  available: number;
+}
+
 export interface PublicApplyJobDetailResponse {
   job_posting: PublicApplyJobPosting;
   application_form: PublicApplyApplicationForm;
+  locations?: LocationPublicSummary[];
+  all_locations_full?: boolean;
 }
 
 export interface CandidateApplicationSubmissionPayload {
   job_posting: number;
   source?: string;
   referral_code?: string | null;
+  location_entry_id?: number | null;
   personal_info: Record<string, unknown>;
   job_details: Record<string, unknown>;
   education_work: Record<string, unknown>;

--- a/src/features/jobs/public/types/jobPublicDetail.types.ts
+++ b/src/features/jobs/public/types/jobPublicDetail.types.ts
@@ -12,4 +12,5 @@ export interface PublicJobDetailResponse {
   responsibilities: string | null;
   qualifications: string | null;
   has_applied?: boolean;
+  all_locations_full?: boolean | null;
 }

--- a/src/features/jobs/public/views/CareerDescription.tsx
+++ b/src/features/jobs/public/views/CareerDescription.tsx
@@ -86,6 +86,12 @@ export default function CareerDescription() {
                 <Briefcase className="h-4 w-4 mr-2" />
                 Already Applied
               </Button>
+            ) : isCandidate && jobPublicDetail?.all_locations_full ? (
+              <div className="bg-gray-100 border border-gray-300 rounded-lg p-4 max-w-md">
+                <p className="text-gray-600 text-sm">
+                  This position is no longer accepting applications.
+                </p>
+              </div>
             ) : isCandidate ? (
               <Button
                 className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2"

--- a/src/features/jobs/public/views/CareersApply.tsx
+++ b/src/features/jobs/public/views/CareersApply.tsx
@@ -19,7 +19,9 @@ import Step01 from "../components/steps/Step01";
 import Step02 from "../components/steps/Step02";
 import Step03 from "../components/steps/Step03";
 import Step04 from "../components/steps/Step04";
+import StepLocation from "../components/steps/StepLocation";
 import type { WorkExperienceEntry, ApplicationFormData } from "../types/application_form.types";
+import type { LocationPublicSummary } from "../types/jobApply.types";
 import { useCandidateApplicationSubmission } from "../hooks/useCandidateApplicationSubmission";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 
@@ -51,11 +53,17 @@ export default function CareersApply() {
   const { submitCandidateApplication, isSubmitting } =
     useCandidateApplicationSubmission();
 
+  const hasLocations = !!(jobDetail?.locations && jobDetail.locations.length > 0);
+
   const {
     formData,
     currentStage,
     acceptTerms,
+    selectedLocationId,
+    locations,
     setAcceptTerms,
+    setSelectedLocationId,
+    handleLocationSelect,
     handleInputPersonalInfo,
     handleInputJobDetails,
     handleInputEducationWork,
@@ -65,7 +73,18 @@ export default function CareersApply() {
     handleQuestionnaireCheckboxInput,
     goToNextStage,
     goToPreviousStage,
-  } = useApplicationForm(jobDetail?.job_posting?.job_title ?? "", prefillFormData);
+  } = useApplicationForm(
+    jobDetail?.job_posting?.job_title ?? "",
+    prefillFormData,
+    hasLocations ? jobDetail.locations : undefined,
+  );
+
+  // Auto-select if only 1 location
+  useEffect(() => {
+    if (locations && locations.length === 1 && locations[0].available > 0) {
+      setSelectedLocationId(locations[0].id);
+    }
+  }, [locations, setSelectedLocationId]);
 
   // Wrapper functions to handle type compatibility
   const handleJobDetailsChange = (
@@ -147,9 +166,16 @@ export default function CareersApply() {
     }
 
     if (currentStage < 4) {
-      if (currentStage === 1 && !acceptTerms) {
-        toast.error("Please accept the data privacy terms to continue.");
-        return;
+      if (currentStage === 1) {
+        if (!acceptTerms) {
+          toast.error("Please accept the data privacy terms to continue.");
+          return;
+        }
+
+        if (hasLocations && !selectedLocationId) {
+          toast.error("Please select a preferred location to continue.");
+          return;
+        }
       }
 
       goToNextStage();
@@ -190,6 +216,7 @@ export default function CareersApply() {
         payload: {
           job_posting: jobDetail.job_posting.id,
           source: "careers_page",
+          location_entry_id: hasLocations ? selectedLocationId : null,
           personal_info: formData.personalInfo,
           job_details: {
             expectedSalary: formData.jobDetails.expectedSalary,
@@ -395,13 +422,24 @@ export default function CareersApply() {
         />
         <div className="flex-1 p-4 lg:p-8">
           {currentStage === 1 && (
-            <Step01
-              formData={formData.personalInfo}
-              applicationForm={jobDetail.application_form.application_form}
-              onInputChange={handleInputPersonalInfo}
-              acceptTerms={acceptTerms}
-              onAcceptTermsChange={setAcceptTerms}
-            />
+            <div className="space-y-8">
+              {hasLocations && locations && (
+                <StepLocation
+                  locations={locations}
+                  selectedLocationId={selectedLocationId}
+                  onLocationSelect={handleLocationSelect}
+                />
+              )}
+              <div className={hasLocations ? "border-t pt-8" : ""}>
+                <Step01
+                  formData={formData.personalInfo}
+                  applicationForm={jobDetail.application_form.application_form}
+                  onInputChange={handleInputPersonalInfo}
+                  acceptTerms={acceptTerms}
+                  onAcceptTermsChange={setAcceptTerms}
+                />
+              </div>
+            </div>
           )}
           {currentStage === 2 && (
             <Step02


### PR DESCRIPTION
…pute headcount from locations

- Add LocationSelectionSection and StepLocation for candidates to choose preferred deployment site during application
- Auto-compute total headcount from locations/batches in external posting form and disable manual headcount input
- Show 'not accepting applications' message on career description when all locations are full
- Include location_entry_id in candidate application submission payload